### PR TITLE
Add loading state management and integrate skeleton loading for loading state in widgets

### DIFF
--- a/lib/app/core/components/content_component.dart
+++ b/lib/app/core/components/content_component.dart
@@ -6,7 +6,7 @@ import '../widgets/title_and_date_widget.dart';
 import 'multimedia_component.dart';
 
 class ContentComponent extends StatelessWidget {
-  final ApodEntity apod;
+  final ApodEntity? apod;
 
   const ContentComponent({super.key, required this.apod});
 
@@ -27,12 +27,12 @@ class ContentComponent extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           TitleAndDateWidget(
-            title: apod.title,
-            date: apod.date,
+            title: apod?.title,
+            date: apod?.date,
           ),
           const SizedBox(height: 16),
           Expanded(
-            child: ExplanationWidget(text: apod.explanation),
+            child: ExplanationWidget(text: apod?.explanation),
           ),
         ],
       ),

--- a/lib/app/core/components/multimedia_component.dart
+++ b/lib/app/core/components/multimedia_component.dart
@@ -1,23 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 import '../entities/apod_entity.dart';
+import '../extensions/context_extension.dart';
 import '../widgets/video_player_widget.dart';
 import '../widgets/zoomable_image_widget.dart';
 
 class MultiMediaComponent extends StatelessWidget {
-  final ApodEntity apod;
+  final ApodEntity? apod;
 
   const MultiMediaComponent({super.key, required this.apod});
 
   @override
   Widget build(BuildContext context) {
-    if (apod.mediaType == MediaType.image) {
-      return ZoomableImageWidget(imageUrl: apod.url);
+    if (apod == null) {
+      return _buildSkeleton(context);
+    }
+    if (apod!.mediaType == MediaType.image) {
+      return ZoomableImageWidget(imageUrl: apod!.url);
     } else {
       return ClipRRect(
         borderRadius: BorderRadius.circular(12),
-        child: VideoPlayerWidget(videoUrl: apod.url),
+        child: VideoPlayerWidget(videoUrl: apod!.url),
       );
     }
+  }
+
+  Widget _buildSkeleton(BuildContext context) {
+    return Skeleton.leaf(
+      enabled: context.isLoading,
+      child: Container(
+        height: 200,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: Colors.grey[700],
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+    );
   }
 }

--- a/lib/app/core/extensions/context_extension.dart
+++ b/lib/app/core/extensions/context_extension.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import '../templates/notifiers/loading_notifier.dart';
+
 extension LocalizationExtension on BuildContext {
   AppLocalizations get loc => AppLocalizations.of(this)!;
 }
 
 extension MediaQueryExtension on BuildContext {
   Size get mediaQuerySize => MediaQuery.of(this).size;
+}
+
+extension LoadingNotifierExtension on BuildContext {
+  bool get isLoading => LoadingNotifier.of(this);
 }

--- a/lib/app/core/l10n/app_pt.arb
+++ b/lib/app/core/l10n/app_pt.arb
@@ -1,6 +1,9 @@
 {
+    "@@locale": "pt",
     "title": "APOD NASA",
-    "@title": {},
+    "@title": {
+        "description": "Label for app title."
+    },
     "favorite": "Favoritar",
     "@favorite": {
         "description": "Label for the button to favorite an item."
@@ -16,5 +19,17 @@
     "empty": "",
     "@empty": {
         "description": "Empty message"
+    },
+    "imageErrorLoading": "Erro ao carregar a imagem",
+    "@imageErrorLoading": {
+        "description": "Label for image loading in cards"
+    },
+    "tryAgain": "Tentar novamente",
+    "@tryAgain": {
+        "description": "Label for image try again button"
+    },
+    "convertToWidget": "Transformar em Widget",
+    "@convertToWidget": {
+        "description": "Label for transform in widget button"
     }
 }

--- a/lib/app/core/templates/base_page.dart
+++ b/lib/app/core/templates/base_page.dart
@@ -3,10 +3,18 @@
 import 'package:flutter/material.dart';
 import 'package:focus_detector/focus_detector.dart';
 
+import 'notifiers/loading_notifier.dart';
+
 abstract class BasePage<VM extends ChangeNotifier> extends StatefulWidget {
   final VM viewModel;
 
-  const BasePage({super.key, required this.viewModel});
+  final bool keepAlive;
+
+  const BasePage({
+    super.key,
+    required this.viewModel,
+    this.keepAlive = true,
+  });
 
   Widget buildPage(BuildContext context, VM viewModel);
 
@@ -38,22 +46,25 @@ class _BasePageState<VM extends ChangeNotifier> extends State<BasePage<VM>>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return FocusDetector(
-      onFocusGained: () {
-        widget.onPageAppear(context, widget.viewModel);
-      },
-      onFocusLost: () {
-        widget.onPageDisappear(context, widget.viewModel);
-      },
-      child: AnimatedBuilder(
-        animation: widget.viewModel,
-        builder: (context, _) {
-          return widget.buildPage(context, widget.viewModel);
+    return LoadingNotifier(
+      notifier: widget.viewModel,
+      child: FocusDetector(
+        onFocusGained: () {
+          widget.onPageAppear(context, widget.viewModel);
         },
+        onFocusLost: () {
+          widget.onPageDisappear(context, widget.viewModel);
+        },
+        child: AnimatedBuilder(
+          animation: widget.viewModel,
+          builder: (context, _) {
+            return widget.buildPage(context, widget.viewModel);
+          },
+        ),
       ),
     );
   }
 
   @override
-  bool get wantKeepAlive => true;
+  bool get wantKeepAlive => widget.keepAlive;
 }

--- a/lib/app/core/templates/notifiers/loading_notifier.dart
+++ b/lib/app/core/templates/notifiers/loading_notifier.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import '../../types/view_model_type.dart';
+
+class LoadingNotifier extends InheritedNotifier<ChangeNotifier> {
+  const LoadingNotifier({
+    super.key,
+    required ChangeNotifier notifier,
+    required super.child,
+  }) : super(notifier: notifier);
+
+  static bool of(BuildContext context) {
+    final notifier =
+        context.dependOnInheritedWidgetOfExactType<LoadingNotifier>();
+    return (notifier?.notifier as ViewModel?)?.isLoading ?? false;
+  }
+}

--- a/lib/app/core/types/view_model_type.dart
+++ b/lib/app/core/types/view_model_type.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+import '../mixins/loading_mixin.dart';
+
+abstract class ViewModel extends ChangeNotifier with LoadingMixin {}

--- a/lib/app/core/widgets/explanation_widget.dart
+++ b/lib/app/core/widgets/explanation_widget.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+import '../extensions/context_extension.dart';
 
 class ExplanationWidget extends StatefulWidget {
-  final String text;
+  final String? text;
 
   const ExplanationWidget({
     super.key,
@@ -15,6 +18,8 @@ class ExplanationWidget extends StatefulWidget {
 class ExplanationWidgetState extends State<ExplanationWidget> {
   @override
   Widget build(BuildContext context) {
+    final isLoading = context.isLoading;
+
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,
@@ -27,25 +32,44 @@ class ExplanationWidgetState extends State<ExplanationWidget> {
           ),
         ],
       ),
-      child: Column(
-        children: [
-          Expanded(
-            child: Scrollbar(
-              thumbVisibility: true,
-              trackVisibility: true,
-              interactive: true,
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  widget.text,
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  textAlign: TextAlign.justify,
+      child: Skeletonizer(
+        enabled: isLoading,
+        child: Column(
+          children: [
+            Expanded(
+              child: Scrollbar(
+                thumbVisibility: true,
+                trackVisibility: true,
+                interactive: true,
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: isLoading
+                      ? _buildSkeletonText(context)
+                      : Text(
+                          widget.text ?? '',
+                          style: Theme.of(context).textTheme.bodyLarge,
+                          textAlign: TextAlign.justify,
+                        ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _buildSkeletonText(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: List.generate(6, (index) {
+        return Container(
+          margin: EdgeInsets.only(bottom: index == 4 ? 0 : 8),
+          width: double.infinity,
+          height: 16,
+          color: Colors.grey[300],
+        );
+      }),
     );
   }
 }

--- a/lib/app/core/widgets/title_and_date_widget.dart
+++ b/lib/app/core/widgets/title_and_date_widget.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
+import '../extensions/context_extension.dart';
 import '../utils/app_pipes.dart';
 
 class TitleAndDateWidget extends StatelessWidget {
-  final String title;
-  final DateTime date;
+  final String? title;
+  final DateTime? date;
 
   const TitleAndDateWidget({
     super.key,
@@ -14,22 +16,50 @@ class TitleAndDateWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      spacing: 8,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Flexible(
-          child: Text(
-            title,
-            style: Theme.of(context).textTheme.titleLarge,
+    final isLoading = context.isLoading;
+
+    return Skeletonizer(
+      enabled: isLoading,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Flexible(
+            child: isLoading
+                ? _buildSkeletonTitle(context)
+                : Text(
+                    title ?? '',
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
           ),
-        ),
-        Text(
-          AppPipes.formatDate(date, format: 'dd/MM/yyyy'),
-          style: Theme.of(context).textTheme.labelMedium,
-        ),
-      ],
+          if (isLoading)
+            _buildSkeletonDate(context)
+          else
+            Text(
+              date != null
+                  ? AppPipes.formatDate(date!, format: 'dd/MM/yyyy')
+                  : '',
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSkeletonTitle(BuildContext context) {
+    return Container(
+      height: 20,
+      width: 200,
+      color: Colors.grey[300],
+      margin: const EdgeInsets.only(right: 8),
+    );
+  }
+
+  Widget _buildSkeletonDate(BuildContext context) {
+    return Container(
+      height: 16,
+      width: 100,
+      color: Colors.grey[300],
     );
   }
 }

--- a/lib/app/core/widgets/video_player_widget.dart
+++ b/lib/app/core/widgets/video_player_widget.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 import 'package:video_player/video_player.dart';
 import 'package:youtube_player_flutter/youtube_player_flutter.dart';
+
+import '../extensions/context_extension.dart';
 
 class VideoPlayerWidget extends StatefulWidget {
   final String videoUrl;
@@ -12,82 +15,117 @@ class VideoPlayerWidget extends StatefulWidget {
 }
 
 class _VideoPlayerWidgetState extends State<VideoPlayerWidget> {
-  late VideoPlayerController _videoController;
+  late final bool _isYoutube;
+  YoutubePlayerController? _youtubeController;
+  VideoPlayerController? _videoController;
 
-  late YoutubePlayerController _youtubeController;
-
-  bool _isYoutube = false;
-  bool _isInitialized = false;
+  late final Future<void> _initializeFuture;
 
   @override
   void initState() {
     super.initState();
-    _initializePlayer();
+    _initializeFuture = _initializePlayer(widget.videoUrl);
   }
 
-  Future<void> _initializePlayer() async {
-    final videoId = YoutubePlayer.convertUrlToId(widget.videoUrl);
+  @override
+  void didUpdateWidget(covariant VideoPlayerWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.videoUrl != widget.videoUrl) {
+      _disposeControllers();
+
+      setState(() {
+        _initializeFuture = _initializePlayer(widget.videoUrl);
+      });
+    }
+  }
+
+  Future<void> _initializePlayer(String url) async {
+    final videoId = YoutubePlayer.convertUrlToId(url);
 
     if (videoId != null) {
       _isYoutube = true;
       _youtubeController = YoutubePlayerController(
         initialVideoId: videoId,
-        flags: const YoutubePlayerFlags(
-          loop: true,
-        ),
+        flags: const YoutubePlayerFlags(loop: true),
       );
 
-      setState(() {
-        _isInitialized = true;
-      });
+      return Future.value();
     } else {
-      _videoController =
-          VideoPlayerController.networkUrl(Uri.parse(widget.videoUrl));
-      try {
-        await _videoController.initialize();
-        _videoController.setLooping(true);
-        _videoController.play();
-        setState(() {
-          _isInitialized = true;
-        });
-      } catch (e) {
-        debugPrint('Erro ao inicializar vídeo: $e');
-        setState(() {
-          _isInitialized = false;
-        });
-      }
+      _isYoutube = false;
+      _videoController = VideoPlayerController.networkUrl(Uri.parse(url));
+      await _videoController!.initialize();
+      _videoController!.setLooping(true);
+      _videoController!.play();
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!_isInitialized) {
-      return const SizedBox(
-        height: 250,
-        child: Center(child: CircularProgressIndicator()),
-      );
-    }
-
-    if (_isYoutube) {
-      return YoutubePlayer(
-        controller: _youtubeController,
-        showVideoProgressIndicator: true,
-      );
-    }
-
-    return AspectRatio(
-      aspectRatio: _videoController.value.aspectRatio,
-      child: VideoPlayer(_videoController),
+    return Skeletonizer(
+      enabled: context.isLoading,
+      child: FutureBuilder<void>(
+        future: _initializeFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const SizedBox(
+              height: 250,
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+      
+          if (snapshot.hasError) {
+            return SizedBox(
+              height: 250,
+              child: Center(
+                child: Text(
+                  'Erro ao inicializar o vídeo: ${snapshot.error}',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+      
+          if (_isYoutube && _youtubeController != null) {
+            return YoutubePlayer(
+              controller: _youtubeController!,
+              showVideoProgressIndicator: true,
+            );
+          }
+      
+          if (!_isYoutube && _videoController != null) {
+            return AspectRatio(
+              aspectRatio: _videoController!.value.aspectRatio,
+              child: VideoPlayer(_videoController!),
+            );
+          }
+      
+          return const SizedBox(
+            height: 250,
+            child: Center(child: Text('Não foi possível reproduzir o vídeo.')),
+          );
+        },
+      ),
     );
   }
 
   @override
   void dispose() {
-    if (_isYoutube) {
-      _youtubeController.dispose();
-    } else {
-      _videoController.dispose();
-    }
+    _disposeControllers();
     super.dispose();
+  }
+
+  @override
+  void deactivate() {
+    super.deactivate();
+    if (_isYoutube && _youtubeController != null) {
+      _youtubeController!.pause();
+    } else if (!_isYoutube && _videoController != null) {
+      _videoController!.pause();
+    }
+  }
+
+  void _disposeControllers() {
+    _youtubeController?.dispose();
+    _videoController?.dispose();
   }
 }

--- a/lib/app/core/widgets/zoomable_image_widget.dart
+++ b/lib/app/core/widgets/zoomable_image_widget.dart
@@ -1,5 +1,8 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+import '../extensions/context_extension.dart';
 
 class ZoomableImageWidget extends StatelessWidget {
   final String imageUrl;
@@ -8,38 +11,60 @@ class ZoomableImageWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isLoading = context.isLoading;
+
     return SafeArea(
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            return InteractiveViewer(
-              minScale: 1,
-              maxScale: 4,
-              child: CachedNetworkImage(
-                imageUrl: imageUrl,
-                fit: BoxFit.contain,
-                imageBuilder: (ctx, imageProvider) {
-                  return ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxWidth: constraints.maxWidth,
-                      maxHeight: constraints.maxHeight,
-                    ),
-                    child: Image(
-                      image: imageProvider,
-                      fit: BoxFit.contain,
-                    ),
-                  );
-                },
-                placeholder: (context, url) => const Center(
-                  child: CircularProgressIndicator(),
+      child: Skeletonizer(
+        enabled: isLoading,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: InteractiveViewer(
+            minScale: 1,
+            maxScale: 4,
+            child: CachedNetworkImage(
+              imageUrl: imageUrl,
+              fit: BoxFit.contain,
+              placeholder: (context, url) => Container(
+                height: 400,
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Colors.grey[800],
+                  borderRadius: BorderRadius.circular(12),
                 ),
-                errorWidget: (_, __, ___) => const Center(
-                  child: Icon(Icons.error, color: Colors.red),
+                child: Center(
+                  child: Icon(Icons.image),
                 ),
               ),
-            );
-          },
+              errorWidget: (context, url, error) => Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.error, color: Colors.red, size: 40),
+                    const SizedBox(height: 8),
+                    Text(
+                      context.loc.imageErrorLoading,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey[700],
+                          ),
+                    ),
+                    const SizedBox(height: 12),
+                    ElevatedButton(
+                      onPressed: () {
+                        Navigator.of(context).pushReplacement(
+                          MaterialPageRoute(
+                            builder: (context) => ZoomableImageWidget(
+                              imageUrl: imageUrl,
+                            ),
+                          ),
+                        );
+                      },
+                      child: Text(context.loc.tryAgain),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/app/modules/favorites_details/presentation/pages/favorite_details_page.dart
+++ b/lib/app/modules/favorites_details/presentation/pages/favorite_details_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/components/content_component.dart';
 import '../../../../core/entities/apod_entity.dart';
+import '../../../../core/extensions/context_extension.dart';
 import '../../../../core/templates/base_page.dart';
 import '../viewmodel/favorite_detail_view_model.dart';
 import '../widgets/details_bottom_action_widget.dart';
@@ -27,24 +28,26 @@ class FavoriteDetailsPage extends BasePage<FavoriteDetailViewModel> {
   Widget buildPage(BuildContext context, FavoriteDetailViewModel viewModel) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('NASA APOD', style: Theme.of(context).textTheme.titleLarge),
+        title: Text(
+          context.loc.title,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
         backgroundColor: Colors.transparent,
       ),
       body: _BodyWidget(viewModel: viewModel),
-      bottomNavigationBar: viewModel.apod.mediaType == MediaType.image
-          ? DetailsBottomActionWidget(
-              onTransformWidget: () {
-                viewModel.saveApodInHome();
-              },
-              onUnfavorite: () async {
-                await viewModel.removeApod(
-                  () {
-                    Navigator.pop(context);
-                  },
-                );
-              },
-            )
-          : null,
+      bottomNavigationBar: DetailsBottomActionWidget(
+        showTransformButton: viewModel.apod.mediaType == MediaType.image,
+        onTransformWidget: () {
+          viewModel.saveApodInHome();
+        },
+        onUnfavorite: () async {
+          await viewModel.removeApod(
+            () {
+              Navigator.pop(context);
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/app/modules/favorites_details/presentation/viewmodel/favorite_detail_view_model.dart
+++ b/lib/app/modules/favorites_details/presentation/viewmodel/favorite_detail_view_model.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/entities/apod_entity.dart';
-import '../../../../core/mixins/loading_mixin.dart';
+import '../../../../core/types/view_model_type.dart';
 import '../../domain/favorite_details_domain.dart';
 
-class FavoriteDetailViewModel extends ChangeNotifier with LoadingMixin {
+class FavoriteDetailViewModel extends ViewModel {
   final SaveApodInHomeService saveApodInHomeService;
   final RemoveApodUseCase removeApodUseCase;
   final ApodEntity apod;

--- a/lib/app/modules/favorites_details/presentation/widgets/details_bottom_action_widget.dart
+++ b/lib/app/modules/favorites_details/presentation/widgets/details_bottom_action_widget.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
+
+import '../../../../core/extensions/context_extension.dart';
 
 class DetailsBottomActionWidget extends StatelessWidget {
+  final bool showTransformButton;
   final VoidCallback onTransformWidget;
   final VoidCallback onUnfavorite;
 
   const DetailsBottomActionWidget({
     super.key,
+    required this.showTransformButton,
     required this.onTransformWidget,
     required this.onUnfavorite,
   });
@@ -18,51 +23,56 @@ class DetailsBottomActionWidget extends StatelessWidget {
           maxHeight: 80,
         ),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          spacing: 4,
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Expanded(
-              child: InkWell(
-                onTap: onTransformWidget,
-                borderRadius: BorderRadius.circular(8),
-                child: Ink(
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).primaryColor,
+        child: Skeletonizer(
+          enabled: context.isLoading,
+          child: Row(
+            spacing: 4,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              if (showTransformButton) ...[
+                Expanded(
+                  child: InkWell(
+                    onTap: onTransformWidget,
                     borderRadius: BorderRadius.circular(8),
+                    child: Ink(
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).primaryColor,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Container(
+                        alignment: Alignment.center,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Text(
+                          context.loc.convertToWidget,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ),
+                    ),
                   ),
-                  child: Container(
-                    alignment: Alignment.center,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: const Text(
-                      'Transformar em Widget',
-                      style: TextStyle(color: Colors.white),
+                ),
+              ],
+              Expanded(
+                child: InkWell(
+                  onTap: onUnfavorite,
+                  borderRadius: BorderRadius.circular(8),
+                  child: Ink(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Container(
+                      alignment: Alignment.center,
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Text(
+                        context.loc.unfavorite,
+                        style: const TextStyle(color: Colors.white),
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-            Expanded(
-              child: InkWell(
-                onTap: onUnfavorite,
-                borderRadius: BorderRadius.circular(8),
-                child: Ink(
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).primaryColor,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Container(
-                    alignment: Alignment.center,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: const Text(
-                      'Desfavoritar',
-                      style: TextStyle(color: Colors.white),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/app/modules/favorites_list/presentation/pages/favorites_list_page.dart
+++ b/lib/app/modules/favorites_list/presentation/pages/favorites_list_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../../../core/entities/apod_entity.dart';
+import '../../../../core/extensions/context_extension.dart';
 import '../../../../core/routes/routes.dart';
 import '../../../../core/templates/base_page.dart';
 import '../../../../core/utils/app_pipes.dart';
@@ -19,32 +21,25 @@ class FavoritesListPage extends BasePage<FavoriteListViewModel> {
 
   @override
   Widget buildPage(BuildContext context, FavoriteListViewModel viewModel) {
-    if (viewModel.favorites.isEmpty) {
-      return Scaffold(
-        appBar: AppBar(
-          title: const Text('APODs Salvos'),
-          backgroundColor: Colors.transparent,
-        ),
-        body: const Center(child: Text('Nenhum APOD salvo ainda')),
-      );
-    }
-
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          'APODs Salvos',
+          context.loc.title,
           style: Theme.of(context).textTheme.titleLarge,
         ),
         backgroundColor: Colors.transparent,
         elevation: 0,
       ),
-      body: ListView.builder(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        itemCount: viewModel.favorites.length,
-        itemBuilder: (context, index) {
-          final apod = viewModel.favorites[index];
-          return _buildApodCard(context, apod);
-        },
+      body: Skeletonizer(
+        enabled: context.isLoading,
+        child: ListView.builder(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          itemCount: viewModel.favorites.length,
+          itemBuilder: (context, index) {
+            final apod = viewModel.favorites[index];
+            return _buildApodCard(context, apod);
+          },
+        ),
       ),
     );
   }
@@ -104,8 +99,16 @@ class FavoritesListPage extends BasePage<FavoriteListViewModel> {
         width: double.infinity,
         height: 200,
         fit: BoxFit.cover,
-        placeholder: (ctx, url) => const Center(
-          child: CircularProgressIndicator(),
+        placeholder: (ctx, url) => Container(
+          height: 200,
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: Colors.grey[800],
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Center(
+            child: Icon(Icons.image),
+          ),
         ),
         errorWidget: (ctx, url, error) => Container(
           height: 200,

--- a/lib/app/modules/favorites_list/presentation/viewmodel/favorite_list_view_model.dart
+++ b/lib/app/modules/favorites_list/presentation/viewmodel/favorite_list_view_model.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:multiple_result/multiple_result.dart';
 
 import '../../../../core/entities/apod_entity.dart';
-import '../../../../core/mixins/loading_mixin.dart';
+import '../../../../core/types/view_model_type.dart';
 import '../../domain/favorite_list_domain.dart';
 
-class FavoriteListViewModel extends ChangeNotifier with LoadingMixin {
+class FavoriteListViewModel extends ViewModel {
   final GetFavoriteListUsecase _getFavoriteListUsecase;
   List<ApodEntity> _favorites = [];
   String? _errorMessage;

--- a/lib/app/modules/home/presentation/page/home_page.dart
+++ b/lib/app/modules/home/presentation/page/home_page.dart
@@ -7,7 +7,6 @@ import '../../../../core/components/content_component.dart';
 import '../viewmodel/home_view_model.dart';
 import '../widgets/bottom_actions_widget.dart';
 import '../widgets/custom_error_widget.dart';
-import '../widgets/loading_widget.dart';
 
 class HomePage extends BasePage<HomeViewModel> {
   const HomePage({
@@ -87,10 +86,6 @@ class _BodyWidget extends StatelessWidget {
       return CustomErrorWidget(errorMessage: viewModel.errorMessage!);
     }
 
-    if (viewModel.apod == null) {
-      return const LoadingWidget();
-    }
-
-    return ContentComponent(apod: viewModel.apod!);
+    return ContentComponent(apod: viewModel.apod);
   }
 }

--- a/lib/app/modules/home/presentation/viewmodel/home_view_model.dart
+++ b/lib/app/modules/home/presentation/viewmodel/home_view_model.dart
@@ -1,15 +1,14 @@
 import 'dart:developer';
 
-import 'package:flutter/material.dart';
 import 'package:multiple_result/multiple_result.dart';
 
 import '../../../../core/entities/apod_entity.dart';
 import '../../../../core/http/failures/http_failure.dart';
-import '../../../../core/mixins/loading_mixin.dart';
+import '../../../../core/types/view_model_type.dart';
 import '../../domain/home_domain.dart';
 import '../common/favorite_button_label.dart';
 
-class HomeViewModel extends ChangeNotifier with LoadingMixin {
+class HomeViewModel extends ViewModel {
   final GetApodUsecase _usecase;
   final SaveApodUsecase _saveApodUsecase;
   final IsPodSavedUsecase _isPodSavedUsecase;
@@ -51,26 +50,20 @@ class HomeViewModel extends ChangeNotifier with LoadingMixin {
   }
 
   Future<bool> isApodSaved() async {
+    bool resultValue = false;
     try {
       final result = await _isPodSavedUsecase(_apod!);
       if (result) {
         _buttonLabel = FavoriteButtonLabel.unfavorite;
-        notifyListeners();
-        return true;
+        resultValue = true;
+      } else {
+        _buttonLabel = FavoriteButtonLabel.favorite;
       }
-      _buttonLabel = FavoriteButtonLabel.favorite;
-      notifyListeners();
-
-      return false;
     } catch (e) {
-      log(
-        name: 'APOD-DATABASE',
-        'Erro inesperado ao verificar se o APOD já está salvo: $e',
-      );
       _buttonLabel = FavoriteButtonLabel.error;
-      notifyListeners();
-      return false;
     }
+    notifyListeners();
+    return resultValue;
   }
 
   Future<String> saveApodToDatabase() async {

--- a/lib/app/modules/home/presentation/widgets/bottom_actions_widget.dart
+++ b/lib/app/modules/home/presentation/widgets/bottom_actions_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
+import '../../../../core/extensions/context_extension.dart';
 import '../common/favorite_button_label.dart';
 
 class BottomActionsWidget extends StatelessWidget {
@@ -22,52 +24,55 @@ class BottomActionsWidget extends StatelessWidget {
           maxHeight: 80,
         ),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Expanded(
-              child: InkWell(
-                onTap: onDateChange,
-                borderRadius: BorderRadius.circular(8),
-                child: Ink(
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).primaryColor,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Container(
-                    alignment: Alignment.center,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: const Icon(
-                      Icons.date_range,
-                      color: Colors.white,
+        child: Skeletonizer(
+          enabled: context.isLoading,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: InkWell(
+                  onTap: onDateChange,
+                  borderRadius: BorderRadius.circular(8),
+                  child: Ink(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Container(
+                      alignment: Alignment.center,
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: const Icon(
+                        Icons.date_range,
+                        color: Colors.white,
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              flex: 4,
-              child: InkWell(
-                onTap: onFavorite,
-                borderRadius: BorderRadius.circular(8),
-                child: Ink(
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).primaryColor,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Container(
-                    alignment: Alignment.center,
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Text(
-                      buttonLabel.getLabel(context),
-                      style: TextStyle(color: Colors.white),
+              const SizedBox(width: 16),
+              Expanded(
+                flex: 4,
+                child: InkWell(
+                  onTap: onFavorite,
+                  borderRadius: BorderRadius.circular(8),
+                  child: Ink(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).primaryColor,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Container(
+                      alignment: Alignment.center,
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      child: Text(
+                        buttonLabel.getLabel(context),
+                        style: TextStyle(color: Colors.white),
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -730,6 +730,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  skeletonizer:
+    dependency: "direct main"
+    description:
+      name: skeletonizer
+      sha256: "0dcacc51c144af4edaf37672072156f49e47036becbc394d7c51850c5c1e884b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   json_annotation: ^4.9.0
   focus_detector: ^2.0.1
   home_widget: ^0.7.0
+  skeletonizer: ^1.4.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION

Este PR implementa o LoadingNotifier para gerenciamento centralizado do estado de carregamento via InheritedNotifier, otimiza o DetailsBottomActionWidget para exibir o botão "Transformar em Widget" apenas para itens do tipo MediaType.image, e melhora a experiência de carregamento com skeletons integrados em widgets como ZoomableImageWidget, VideoPlayerWidget, e CardVideoPlayerWidget, garantindo uma UX mais fluida e código mais limpo.